### PR TITLE
handle js and linting with webpack

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,4 +1,41 @@
-// Fill this in...
-module.exports = {
+let path = require('path');
+let StyleLintPlugin = require('stylelint-webpack-plugin');
+let paths = {
+    js: './application/themes/shs/js',
+    sass: './application/themes/shs/css/scss',
+};
 
+module.exports = {
+    devtool: 'source-map',
+    entry: `${paths.js}/index.js`,
+    output: {
+        path: path.resolve(__dirname, paths.js),
+        filename: 'bundle.js',
+    },
+    module: {
+        rules: [{
+            test: /\.js$/,
+            exclude: /node_modules/,
+            use: {
+                loader: 'babel-loader',
+                options: {
+                    presets: ['@babel/preset-env']
+                }
+            }
+        },
+        {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            use: {
+                loader: 'eslint-loader'
+            }
+        }
+        ],
+    },
+    plugins: [
+        new StyleLintPlugin({
+            files: paths.scss,
+            syntax: 'scss'
+        }),
+    ]
 };


### PR DESCRIPTION
What is the purpose?
I suggest we handle JS bundling, eslint, and stlyelint within the webpack bundle, so that it can listen for changes as we make them.

How would we implement this idea?
We will need to add gulp and webpack libs to a package.json file.

Supporting Materials
I have a list of some of the latest babel and webpack libs that i'm using in a test repo, including stylelint-webpack-plugin.